### PR TITLE
Add High res timer class

### DIFF
--- a/source/Configuration.cs
+++ b/source/Configuration.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿//
+// Copyright (c) 2018 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
 using Windows.Devices.Gpio;
 
 namespace nanoFramework.Hardware.Esp32

--- a/source/DeviceTypePins.cs
+++ b/source/DeviceTypePins.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿//
+// Copyright (c) 2018 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
 
 namespace nanoFramework.Hardware.Esp32
 {

--- a/source/Errors.cs
+++ b/source/Errors.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿//
+// Copyright (c) 2018 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
 
 namespace nanoFramework.Hardware.Esp32
 {

--- a/source/HighResEventListener.cs
+++ b/source/HighResEventListener.cs
@@ -1,0 +1,83 @@
+﻿//
+// Copyright (c) 2018 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections;
+using nanoFramework.Runtime.Events;
+
+namespace nanoFramework.Hardware.Esp32
+{
+    internal class HighResEventListener : IEventProcessor, IEventListener
+    {
+        System.Collections.ArrayList HighResTimers = new ArrayList();
+
+
+        public HighResEventListener()
+        {
+            EventSink.AddEventProcessor(EventCategory.Custom, this);
+            EventSink.AddEventListener(EventCategory.Custom, this);
+        }
+
+        public void InitializeForEventSource()
+        {
+        }
+
+        /// <summary>
+        /// Fire event on correct timer
+        /// </summary>
+        /// <param name="ev"></param>
+        /// <returns></returns>
+        public bool OnEvent(BaseEvent ev)
+        {
+            if ( ev is HighResTimerEvent)
+            {
+                foreach (object obj in HighResTimers)
+                {
+                    HighResTimer timer = obj as HighResTimer;
+                    if (timer._timerHandle == ((HighResTimerEvent)ev).TimerHandle)
+                    {
+                        timer.OnHighResTimerExpiredInternal((HighResTimerEvent)ev);
+                        break;
+                    }
+                }
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Process an event
+        /// </summary>
+        /// <param name="data1"></param>
+        /// <param name="data2"></param>
+        /// <param name="time"></param>
+        /// <returns></returns>
+        public BaseEvent ProcessEvent(uint data1, uint data2, DateTime time)
+        {
+            HighResTimerEventType eventType = (HighResTimerEventType)(data1 & 0xFF);
+            
+            if (eventType >= HighResTimerEventType.TimerExpired)
+            {
+                HighResTimerEvent timerEvent = new HighResTimerEvent();
+                timerEvent.EventType = eventType;
+                timerEvent.TimerHandle = data2;
+
+                return timerEvent;
+            }
+            return null;
+        }
+
+
+        internal void AddHighResTimer(HighResTimer timer)
+        {
+            HighResTimers.Add(timer);
+        }
+
+        internal void RemoveHighResTimer(HighResTimer timer)
+        {
+            HighResTimers.Remove(timer);
+        }
+    }
+}

--- a/source/HighResTimer.cs
+++ b/source/HighResTimer.cs
@@ -1,0 +1,168 @@
+﻿//
+// Copyright (c) 2018 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Runtime.CompilerServices;
+using nanoFramework.Runtime.Events;
+
+namespace nanoFramework.Hardware.Esp32
+{
+    /// <summary>
+    /// Event raised when a High res timer expires. 
+    /// </summary>
+    public delegate void HighResTimerExpiredEventHandler(
+                            HighResTimer sender,
+                            Object e);
+
+
+    /// <summary>
+    /// The class encapsulates the ESP32 High Resolution Timer API.
+    /// </summary>
+    public class HighResTimer : IDisposable
+    {
+        internal Int32 _timerHandle;
+        internal bool  _disposedValue = false; // To detect redundant calls
+
+
+        private static HighResEventListener s_eventListener = new HighResEventListener();
+
+        // This is used as the lock object 
+        // a lock is required because multiple threads can access the HighResTimer
+        private object _syncLock = new object();
+
+        /// <summary>
+        /// Event raised when a HighRes timer expires.  
+        /// </summary>
+        public event HighResTimerExpiredEventHandler OnHighResTimerExpired;
+
+
+        internal void OnHighResTimerExpiredInternal(object e)
+        {
+            HighResTimerExpiredEventHandler callbacks = null;
+
+            lock (_syncLock)
+            {
+                if (!_disposedValue)
+                {
+                    callbacks = OnHighResTimerExpired;
+                }
+            }
+
+            callbacks?.Invoke(this, new EventArgs());
+        }
+
+        /// <summary>
+        /// Returns the number of micro seconds since boot
+        /// </summary>
+        /// <returns></returns>
+        public static UInt64 GetCurrent()
+        {
+            return NativeGetCurrent();
+        }
+
+        /// <summary>
+        /// Create a High Resolution Timer. A maximum of 10 timers can be created.
+        /// </summary>
+        public HighResTimer()
+        {
+            _timerHandle = NativeEspTimerCreate();
+            s_eventListener.AddHighResTimer(this);
+        }
+
+
+        /// <summary>
+        /// Stop the Timer.
+        /// </summary>
+        public void Stop()
+        {
+            NativeStop();
+        }
+
+        /// <summary>
+        /// Start a one shot timer.
+        /// Once the timer has expired the timer event will be fired.
+        /// </summary>
+        /// <param name="timeout_us">Timeout in mirco seconds</param>
+        public void StartOneShot(UInt64 timeout_us)
+        {
+            NativeStartOneShot(timeout_us);
+        }
+
+        /// <summary>
+        /// Start a periodic timer.
+        /// </summary>
+        /// <param name="period_us">Period between firing timer events.</param>
+        /// <returns></returns>
+        public void StartOnePeriodic(UInt64 period_us)
+        {
+            NativeStartPeriodic(period_us);
+        }
+
+        #region IDisposable Support
+
+        /// <summary>
+        /// Dispose(bool disposing)
+        /// </summary>
+        /// <param name="disposing"></param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    // TODO: dispose managed state (managed objects).
+                }
+
+                s_eventListener.RemoveHighResTimer(this);
+
+                NativeEspTimerDispose();
+
+                _disposedValue = true;
+            }
+        }
+
+        /// <summary>
+        /// Finalizer
+        /// </summary>
+        ~HighResTimer()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose HighResTimer
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+
+            GC.SuppressFinalize(this);
+        }
+        #endregion
+
+        #region Native Calls
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private extern Int32 NativeEspTimerCreate();
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private extern void NativeEspTimerDispose();
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern UInt64 NativeGetCurrent();
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private extern void NativeStop();
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private extern void NativeStartOneShot(UInt64 timeout);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private extern void NativeStartPeriodic(UInt64 period);
+
+        #endregion
+    }
+
+}

--- a/source/HighResTimerEvent.cs
+++ b/source/HighResTimerEvent.cs
@@ -1,0 +1,24 @@
+﻿//
+// Copyright (c) 2018 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
+using nanoFramework.Runtime.Events;
+
+
+namespace nanoFramework.Hardware.Esp32
+{
+    [Flags]
+    internal enum HighResTimerEventType : byte
+    {
+        TimerExpired = 101             // HighRes Timer expired event
+    }
+
+    internal class HighResTimerEvent : BaseEvent
+    {
+        public HighResTimerEventType EventType;
+        public uint TimerHandle;
+
+    }
+}

--- a/source/Logging.cs
+++ b/source/Logging.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿//
+// Copyright (c) 2018 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
 using System.Runtime.CompilerServices;
 
 namespace nanoFramework.Hardware.Esp32

--- a/source/Sleep.cs
+++ b/source/Sleep.cs
@@ -1,3 +1,8 @@
+//
+// Copyright (c) 2018 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
 using System;
 using System.Runtime.CompilerServices;
 

--- a/source/nanoFramework.Hardware.Esp32.nfproj
+++ b/source/nanoFramework.Hardware.Esp32.nfproj
@@ -57,6 +57,9 @@
   </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
+    <Compile Include="HighResEventListener.cs" />
+    <Compile Include="HighResTimer.cs" />
+    <Compile Include="HighResTimerEvent.cs" />
     <Compile Include="Logging.cs" />
     <Compile Include="Configuration.cs" />
     <Compile Include="DeviceTypePins.cs" />


### PR DESCRIPTION
This adds the encapsulation of the high res timer class.

Has 1 static method to get the current time in micro second since boot.

The rest encapsulates the High res timer to fire one shot or periodic events.
Current uses the Custom event.

Not sure if we will keep this as the latency on the events is too long making the event a bit pointless as you could just use the normal Timer class. Maybe a better way to do events which has less latency.

Current uses the Custom Event
