### PR TITLE
Update 'WakeupCause' enum to match IDF 

### DIFF
--- a/source/nanoFramework.Hardware.Esp32/Sleep.cs
+++ b/source/nanoFramework.Hardware.Esp32/Sleep.cs
@@ -35,9 +35,13 @@ namespace nanoFramework.Hardware.Esp32
         public enum WakeupCause
         {
             /// <summary>
-            /// Wakeup not caused from exit from sleep
+            /// In case of deep sleep, reset was not caused by exit from deep sleep
             /// </summary>
             Undefined = 0,
+            /// <summary>
+            /// Not a wakeup cause, used to disable all wakeup sources with esp_sleep_disable_wakeup_source
+            /// </summary>
+			All,
             /// <summary>
             /// Wakeup caused by external signal using RTC_IO
             /// </summary>
@@ -57,7 +61,15 @@ namespace nanoFramework.Hardware.Esp32
             /// <summary>
             ///  Wakeup caused by ULP program
             /// </summary>
-            Ulp          
+            Ulp,
+            /// <summary>
+            /// Wakeup caused by GPIO (light sleep only)
+            /// </summary>
+            Gpio,
+            /// <summary>
+            /// Wakeup caused by UART (light sleep only)
+            /// </summary>
+            Uart
         };
 
 

--- a/source/nanoFramework.Hardware.Esp32/Sleep.cs
+++ b/source/nanoFramework.Hardware.Esp32/Sleep.cs
@@ -39,13 +39,9 @@ namespace nanoFramework.Hardware.Esp32
             /// </summary>
             Undefined = 0,
             /// <summary>
-            /// Not a wakeup cause, used to disable all wakeup sources with esp_sleep_disable_wakeup_source
-            /// </summary>
-			All,
-            /// <summary>
             /// Wakeup caused by external signal using RTC_IO
             /// </summary>
-            Ext0,         
+            Ext0 = 2,         
             /// <summary>
             /// Wakeup caused by external signal using RTC_CNTL
             /// </summary>


### PR DESCRIPTION
## Description
Added 3 missing entries in the enum 'WakeUpCause':

- WakeupCause.All
- WakeupCause.Gpio
- WakeupCause.Uart

These entries are declared in the original C enum 'esp_sleep_source_t', but were missing in C#.
The 2 last entries comes at the end of the enum and have no effect on the integer value of the enum entries, but 'WakeupCause.All' comes in second position of the enum and changes the ordinal of all following entries.

## Motivation and Context
When returning from sleep, the enum value returned by 'Sleep.GetWakeupCause()' does not match the actual cause of the sleep.

## How Has This Been Tested?
Basic test: Using the sample project 'HardwareEsp32', the return value of 'Sleep.GetWakeupCause()' was casted to the new declaration of the enum with success.

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: oleneveu <oleneveu@gmail.com>
