### PR TITLE
Fix issue with Sleep and wake from sleep

### DIFF
--- a/nanoFramework.Hardware.Esp32/Properties/AssemblyInfo.cs
+++ b/nanoFramework.Hardware.Esp32/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 
 ////////////////////////////////////////////////////////////////
 // update this whenever the native assembly signature changes //
-[assembly: AssemblyNativeVersion("100.0.7.1")]
+[assembly: AssemblyNativeVersion("100.0.7.2")]
 ////////////////////////////////////////////////////////////////
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/nanoFramework.Hardware.Esp32/Sleep.cs
+++ b/nanoFramework.Hardware.Esp32/Sleep.cs
@@ -86,71 +86,71 @@ namespace nanoFramework.Hardware.Esp32
             /// <summary>
             /// Gpio Pin 2 used for wakeup
             /// </summary>
-            Pin2 = 1 << 2,
+            Pin2 = (UInt64)1 << 2,
             /// <summary>
             /// Gpio Pin 4 used for wakeup
             /// </summary>
-            Pin4 = 1 << 4,
+            Pin4 = (UInt64)1 << 4,
             /// <summary>
             /// Gpio Pin 12 used for wakeup
             /// </summary>
-            Pin12 = 1 << 12,
+            Pin12 = (UInt64)1 << 12,
             /// <summary>
             /// Gpio Pin 13 used for wakeup
             /// </summary>
-            Pin13 = 1 << 13,
+            Pin13 = (UInt64)1 << 13,
             /// <summary>
             /// Gpio Pin 14 used for wakeup
             /// </summary>
-            Pin14 = 1 << 14,
+            Pin14 = (UInt64)1 << 14,
             /// <summary>
             /// Gpio Pin 15 used for wakeup
             /// </summary>
-            Pin15 = 1 << 15,
+            Pin15 = (UInt64)1 << 15,
             /// <summary>
             /// Gpio Pin 25 used for wakeup
             /// </summary>
-            Pin25 = 1 << 25,
+            Pin25 = (UInt64)1 << 25,
             /// <summary>
             /// Gpio Pin 26 used for wakeup
             /// </summary>
-            Pin26 = 1 << 26,
+            Pin26 = (UInt64)1 << 26,
             /// <summary>
             /// Gpio Pin 27 used for wakeup
             /// </summary>
-            Pin27 = 1 << 27,
+            Pin27 = (UInt64)1 << 27,
             /// <summary>
             /// Gpio Pin 32 used for wakeup
             /// </summary>
-            Pin32 = 1 << 32,
+            Pin32 = (UInt64)1 << 32,
             /// <summary>
             /// Gpio Pin 33 used for wakeup
             /// </summary>
-            Pin33 = 1 << 33,
+            Pin33 = (UInt64)1 << 33,
             /// <summary>
             /// Gpio Pin 34 used for wakeup
             /// </summary>
-            Pin34 = 1 << 34,
+            Pin34 = (UInt64)1 << 34,
             /// <summary>
             /// Gpio Pin 35 used for wakeup
             /// </summary>
-            Pin35 = 1 << 35,
+            Pin35 = (UInt64)1 << 35,
             /// <summary>
             /// Gpio Pin 36 used for wakeup
             /// </summary>
-            Pin36 = 1 << 36,
+            Pin36 = (UInt64)1 << 36,
             /// <summary>
             /// Gpio Pin 37 used for wakeup
             /// </summary>
-            Pin37 = 1 << 37,
+            Pin37 = (UInt64)1 << 37,
             /// <summary>
             /// Gpio Pin 38 used for wakeup
             /// </summary>
-            Pin38 = 1 << 38,
+            Pin38 = (UInt64)1 << 38,
             /// <summary>
             /// Gpio Pin 39 used for wakeup
             /// </summary>
-            Pin39 = 1 << 39
+            Pin39 = (UInt64)1 << 39
         };
 
         /// <summary>


### PR DESCRIPTION
## Description
- When fixing issue #705 I noticed a problem in the declaration of  enum &lt;&lt;WakeupGpioPin&gt;&gt;. All enums above Pin 27 overflows and starts from 1 again.
- This is fixed by changing "Pinxx = 1 << xx" to "Pinxx = (UInt64)1 << xx" in the &lt;&lt;WakeupGpioPin&gt;&gt; enum declaration.
- Part of nanoframework/nf-interpreter#1852.


## Motivation and Context
- The methods &lt;&lt;EnableWakeupByPin&gt;&gt; and &lt;&lt;EnableWakeupByMultiPins&gt;&gt; will fail when using GPIO pins higher than 27.
- Addresses nanoFramework/Home#705.

Tested:

- Running an application that exercises &lt;&lt;EnableWakeupByPin&gt;&gt;, using low and high pin numbers. 

- Added a temporary console output in the native &lt;&lt;EnableWakeupByPin&gt;&gt; method in nF-interpreter to print the mask value to screen to ensure it passed down correctly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
